### PR TITLE
Fix sparqlblocks reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "^4.14.0",
     "loggly": "^1.1.0",
     "socket.io": "^1.4.8",
-    "sparqlblocks": "github:miguel76/SparqlBlocks",
+    "sparqlblocks": "miguel76/SparqlBlocks",
     "winston": "^2.2.0",
     "winston-aws-cloudwatch": "^1.4.0",
     "winston-loggly-bulk": "^1.3.3"


### PR DESCRIPTION
npm 1.4.21 does not recognize the `github:` prefix and tries to look up the package name on npmjs.com instead.

See https://docs.npmjs.com/files/package.json#github-urls